### PR TITLE
Feature/18

### DIFF
--- a/.direnv/bin/nix-direnv-reload
+++ b/.direnv/bin/nix-direnv-reload
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+dir="$(realpath $(dirname ${BASH_SOURCE[0]})/../..)"
+_nix_direnv_force_reload=1 direnv exec "$dir" true
+direnv reload
+# direnv reload updates the mtime of .envrc. Also update the timestamp of the
+# profile_rc file to keep track that we actually are up to date.
+touch $dir/.direnv/{nix,flake}-profile-*.rc
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,11 @@ description = "Data structures in Rust."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0.190", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.5.1"
+serde_json = "1.0.1"
 
 [[bench]]
 name = "binary_tree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0.190", optional = true, features = ["derive"] }
 [dev-dependencies]
 criterion = "0.5.1"
 serde_json = "1.0.1"
+rstest = "0.18.2"
 
 [[bench]]
 name = "binary_tree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0.190", optional = true, features = ["derive"] }
 criterion = "0.5.1"
 serde_json = "1.0.1"
 rstest = "0.18.2"
+rand = "0.8.5"
 
 [[bench]]
 name = "binary_tree"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# Cargo
+To properly use `clippy` and execute tests for this library, you need to use a couple of important flags.
+
+```
+cargo clippy --all-features --all-targets -- -D warnings
+```
+
+This ensures that all compilation targets are checked, and that warnings present as errors - which is how the CI handles warnings.
+As such, if you only run `cargo clippy` and get no warnings, there may still be warnings, which becomes errors when the CI checks the code.
+
+```
+cargo test --all-targets --all-features
+```
+
+Similarly, this ensures that all compilation targets and paths are tested - again, this is what the CI does when it tests the code, so it should also be the default for any developer.
+
 # Branching
 ## Naming
 Branches should be named so that they can lead back to the issue they relate to, and so as to indicate the purpose of the branch.

--- a/benches/binary_tree.rs
+++ b/benches/binary_tree.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ds_rs::binary_tree::BinaryTree;
+use rand::{thread_rng, Rng};
 
 pub fn insert(c: &mut Criterion) {
     let mut tree = BinaryTree::new();
@@ -64,5 +65,21 @@ pub fn insert(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, insert);
+pub fn into_iter(c: &mut Criterion) {
+    let mut tree = BinaryTree::new();
+
+    for _ in 0..10000 {
+        let rand_num = thread_rng().gen_range(i32::MIN..i32::MAX);
+        tree.insert(rand_num);
+    }
+
+    c.bench_function("create iterator from 10.000 element tree", |b| {
+        b.iter(|| {
+            let iter = tree.clone().into_iter();
+            iter.for_each(|_| {});
+        })
+    });
+}
+
+criterion_group!(benches, insert, into_iter);
 criterion_main!(benches);

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -64,7 +64,7 @@ impl<T: PartialOrd> BinaryTree<T> {
                                 Ord::Less => root.set_left(value),
                                 Ord::Greater => root.set_right(value),
                             }
-                            self.height = level;
+                            self.height = self.height.max(level);
                             self.count += 1;
                             return;
                         }
@@ -72,7 +72,7 @@ impl<T: PartialOrd> BinaryTree<T> {
                             Ord::Equal => return,
                             Ord::Less => {
                                 root.set_left(value);
-                                self.height = level;
+                                self.height = self.height.max(level);
                                 self.count += 1;
                                 return;
                             }
@@ -83,7 +83,7 @@ impl<T: PartialOrd> BinaryTree<T> {
                             Ord::Less => root = root.left_mut().unwrap(),
                             Ord::Greater => {
                                 root.set_right(value);
-                                self.height = level;
+                                self.height = self.height.max(level);
                                 self.count += 1;
                                 return;
                             }
@@ -921,6 +921,32 @@ mod binary_tree_insert {
         let mut tree = BinaryTree::new();
         tree.insert(2.0);
         tree.insert(f64::NAN);
+    }
+
+    #[test]
+    fn inserts_unevenly_and_ensures_correct_height() {
+        let mut tree = BinaryTree::new();
+        let expected = 3;
+
+        tree.insert(2);
+        tree.insert(1);
+        tree.insert(0);
+        tree.insert(3);
+
+        assert_eq!(tree.height(), expected);
+    }
+
+    #[test]
+    fn inserts_unevenly_and_ensures_correct_count() {
+        let mut tree = BinaryTree::new();
+        let expected = 4;
+
+        tree.insert(2);
+        tree.insert(1);
+        tree.insert(0);
+        tree.insert(3);
+
+        assert_eq!(tree.count(), expected);
     }
 }
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -454,13 +454,13 @@ impl<T: PartialOrd> Node<T> {
     /// Creates a new `Node` from the provided value, and set it as the left child of `self`.
     #[inline]
     pub fn set_left(&mut self, value: T) {
-        self.left = Some(Box::new(Node::new(value)))
+        self.left = Some(Box::new(Node::new(value)));
     }
 
     /// Creates a new `Node` from the provided value, and set it as the right child of `self`.
     #[inline]
     pub fn set_right(&mut self, value: T) {
-        self.right = Some(Box::new(Node::new(value)))
+        self.right = Some(Box::new(Node::new(value)));
     }
 }
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -917,3 +917,40 @@ mod binary_tree_insert {
         tree.insert(f64::NAN);
     }
 }
+
+#[cfg(test)]
+mod binary_tree_std_trait_impls {
+    use super::{BinaryTree, Item};
+
+    #[test]
+    fn creates_tree_from_vec() {
+        let values = vec![5, 4, 6];
+        let expected = BinaryTree {
+            root: Some(Box::new(Item {
+                value: 5,
+                left: Some(Box::new(Item {
+                    value: 4,
+                    left: None,
+                    right: None,
+                })),
+                right: Some(Box::new(Item {
+                    value: 6,
+                    left: None,
+                    right: None,
+                })),
+            })),
+            count: 3,
+            height: 2,
+        };
+
+        let tree = BinaryTree::from(values);
+        assert_eq!(tree, expected);
+    }
+
+    #[test]
+    #[should_panic]
+    fn panics_when_creating_from_vec_of_incomparable_elements() {
+        let values = vec![5.0, 4.0, 6.0, f64::NAN];
+        _ = BinaryTree::from(values);
+    }
+}

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -7,7 +7,7 @@ pub struct BinaryTree<T>
 where
     T: PartialOrd,
 {
-    root: Option<Box<Item<T>>>,
+    root: Option<Box<Node<T>>>,
     count: usize,
     height: usize,
 }
@@ -102,7 +102,7 @@ impl<T: PartialOrd> BinaryTree<T> {
                 // This ensures that root is not an imcomparable value.
                 _ = value.partial_cmp(&value).unwrap();
 
-                self.root = Some(Box::new(Item::new(value)));
+                self.root = Some(Box::new(Node::new(value)));
                 self.count = 1;
                 self.height = 1;
             }
@@ -245,7 +245,7 @@ impl<T: PartialOrd> IntoIterator for BinaryTree<T> {
     type IntoIter = BinaryTreeIterator<T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        fn into_iter_rec<T>(node: Item<T>, vec: &mut Vec<T>) {
+        fn into_iter_rec<T>(node: Node<T>, vec: &mut Vec<T>) {
             vec.push(node.value);
 
             if let Some(left) = node.left {
@@ -297,16 +297,16 @@ impl<T: PartialOrd> FromIterator<T> for BinaryTree<T> {
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
-struct Item<T> {
+struct Node<T> {
     value: T,
-    left: Option<Box<Item<T>>>,
-    right: Option<Box<Item<T>>>,
+    left: Option<Box<Node<T>>>,
+    right: Option<Box<Node<T>>>,
 }
 
-impl<T: PartialOrd> Item<T> {
-    /// Constructs a new empty `Item<T>`.
+impl<T: PartialOrd> Node<T> {
+    /// Constructs a new empty `Node<T>`.
     ///
-    /// An item has no left or right child.
+    /// An node has no left or right child.
     pub fn new(value: T) -> Self {
         Self {
             value,
@@ -315,194 +315,194 @@ impl<T: PartialOrd> Item<T> {
         }
     }
 
-    /// Returns a reference to the value of the item.
+    /// Returns a reference to the value of the node.
     pub fn value(&self) -> &T {
         &self.value
     }
 
-    /// Returns an `Option` containing a reference to the left child of the item.
+    /// Returns an `Option` containing a reference to the left child of the node.
     pub fn left(&self) -> Option<&Self> {
         self.left.as_deref()
     }
 
-    /// Returns an `Option` containing a reference to the right child of the item.
+    /// Returns an `Option` containing a reference to the right child of the node.
     pub fn right(&self) -> Option<&Self> {
         self.right.as_deref()
     }
 
-    /// Returns an `Option` containing a mutable reference to the left child of the item.
+    /// Returns an `Option` containing a mutable reference to the left child of the node.
     pub fn left_mut(&mut self) -> Option<&mut Self> {
         self.left.as_deref_mut()
     }
 
-    /// Returns an `Option` containing a mutable reference to the right child of the item.
+    /// Returns an `Option` containing a mutable reference to the right child of the node.
     pub fn right_mut(&mut self) -> Option<&mut Self> {
         self.right.as_deref_mut()
     }
 
-    /// Creates a new `Item` from the provided value, and set it as the left child of `self`.
+    /// Creates a new `Node` from the provided value, and set it as the left child of `self`.
     pub fn set_left(&mut self, value: T) {
-        self.left = Some(Box::new(Item::new(value)))
+        self.left = Some(Box::new(Node::new(value)))
     }
 
-    /// Creates a new `Item` from the provided value, and set it as the right child of `self`.
+    /// Creates a new `Node` from the provided value, and set it as the right child of `self`.
     pub fn set_right(&mut self, value: T) {
-        self.right = Some(Box::new(Item::new(value)))
+        self.right = Some(Box::new(Node::new(value)))
     }
 }
 
 #[cfg(test)]
-mod item {
-    use super::Item;
+mod node {
+    use super::Node;
 
     #[test]
     fn gets_the_value() {
-        let item = Item {
+        let node = Node {
             value: 5,
             left: None,
             right: None,
         };
-        assert_eq!(item.value(), &5);
+        assert_eq!(node.value(), &5);
     }
 
     #[test]
     fn gets_left_child_that_is_none() {
-        let item = Item {
+        let node = Node {
             value: 0,
             left: None,
             right: None,
         };
         let expected = None;
 
-        assert_eq!(item.left(), expected);
+        assert_eq!(node.left(), expected);
     }
 
     #[test]
     fn gets_left_child_that_is_some() {
-        let item = Item {
+        let node = Node {
             value: 0,
-            left: Some(Box::new(Item {
+            left: Some(Box::new(Node {
                 value: 5,
                 left: None,
                 right: None,
             })),
             right: None,
         };
-        let expected = Some(&Item {
+        let expected = Some(&Node {
             value: 5,
             left: None,
             right: None,
         });
 
-        assert_eq!(item.left(), expected);
+        assert_eq!(node.left(), expected);
     }
 
     #[test]
     fn gets_right_child_that_is_none() {
-        let item = Item {
+        let node = Node {
             value: 0,
             left: None,
             right: None,
         };
         let expected = None;
 
-        assert_eq!(item.right(), expected);
+        assert_eq!(node.right(), expected);
     }
 
     #[test]
     fn gets_right_child_that_is_some() {
-        let item = Item {
+        let node = Node {
             value: 0,
             left: None,
-            right: Some(Box::new(Item {
+            right: Some(Box::new(Node {
                 value: 5,
                 left: None,
                 right: None,
             })),
         };
-        let expected = Some(&Item {
+        let expected = Some(&Node {
             value: 5,
             left: None,
             right: None,
         });
 
-        assert_eq!(item.right(), expected);
+        assert_eq!(node.right(), expected);
     }
 
     #[test]
     fn gets_mut_left_child_that_is_none() {
-        let mut item = Item {
+        let mut node = Node {
             value: 0,
             left: None,
             right: None,
         };
         let expected = None;
 
-        assert_eq!(item.left_mut(), expected);
+        assert_eq!(node.left_mut(), expected);
     }
 
     #[test]
     fn gets_mut_left_child_that_is_some() {
-        let mut item = Item {
+        let mut node = Node {
             value: 0,
-            left: Some(Box::new(Item {
+            left: Some(Box::new(Node {
                 value: -1,
                 left: None,
                 right: None,
             })),
             right: None,
         };
-        let mut expected = Item {
+        let mut expected = Node {
             value: -1,
             left: None,
             right: None,
         };
 
-        assert_eq!(item.left_mut(), Some(&mut expected));
+        assert_eq!(node.left_mut(), Some(&mut expected));
     }
 
     #[test]
     fn gets_mut_right_child_that_is_none() {
-        let mut item = Item {
+        let mut node = Node {
             value: 0,
             left: None,
             right: None,
         };
         let expected = None;
 
-        assert_eq!(item.right_mut(), expected);
+        assert_eq!(node.right_mut(), expected);
     }
 
     #[test]
     fn gets_mut_right_child_that_is_some() {
-        let mut item = Item {
+        let mut node = Node {
             value: 0,
             left: None,
-            right: Some(Box::new(Item {
+            right: Some(Box::new(Node {
                 value: 1,
                 left: None,
                 right: None,
             })),
         };
-        let mut expected = Item {
+        let mut expected = Node {
             value: 1,
             left: None,
             right: None,
         };
 
-        assert_eq!(item.right_mut(), Some(&mut expected));
+        assert_eq!(node.right_mut(), Some(&mut expected));
     }
 
     #[test]
     fn sets_left() {
-        let mut item = Item {
+        let mut node = Node {
             value: 0,
             left: None,
             right: None,
         };
-        let expected = Item {
+        let expected = Node {
             value: 0,
-            left: Some(Box::new(Item {
+            left: Some(Box::new(Node {
                 value: -1,
                 left: None,
                 right: None,
@@ -510,35 +510,35 @@ mod item {
             right: None,
         };
 
-        item.set_left(-1);
-        assert_eq!(item, expected);
+        node.set_left(-1);
+        assert_eq!(node, expected);
     }
 
     #[test]
     fn sets_right() {
-        let mut item = Item {
+        let mut node = Node {
             value: 0,
             left: None,
             right: None,
         };
-        let expected = Item {
+        let expected = Node {
             value: 0,
             left: None,
-            right: Some(Box::new(Item {
+            right: Some(Box::new(Node {
                 value: 1,
                 left: None,
                 right: None,
             })),
         };
 
-        item.set_right(1);
-        assert_eq!(item, expected);
+        node.set_right(1);
+        assert_eq!(node, expected);
     }
 }
 
 #[cfg(test)]
 mod binary_tree_getters {
-    use super::{BinaryTree, Item};
+    use super::{BinaryTree, Node};
 
     #[test]
     fn count() {
@@ -565,7 +565,7 @@ mod binary_tree_getters {
     #[test]
     fn is_empty() {
         let tree = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
                 left: None,
                 right: None,
@@ -586,7 +586,7 @@ mod binary_tree_getters {
     #[test]
     fn clear() {
         let mut tree = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
                 left: None,
                 right: None,
@@ -610,7 +610,7 @@ mod binary_tree_getters {
     #[test]
     fn root() {
         let tree = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
                 left: None,
                 right: None,
@@ -631,13 +631,13 @@ mod binary_tree_getters {
 
 #[cfg(test)]
 mod binary_tree_insert {
-    use super::{BinaryTree, Item};
+    use super::{BinaryTree, Node};
 
     #[test]
     fn insert_one_element_that_becomes_root() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
                 left: None,
                 right: None,
@@ -653,9 +653,9 @@ mod binary_tree_insert {
     fn inserts_two_elements_second_is_left_child() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 4,
                     left: None,
                     right: None,
@@ -674,10 +674,10 @@ mod binary_tree_insert {
     fn inserts_two_elements_second_is_right_child() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
                 left: None,
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 6,
                     left: None,
                     right: None,
@@ -695,7 +695,7 @@ mod binary_tree_insert {
     fn discards_duplicate_inserts_of_root() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
                 left: None,
                 right: None,
@@ -712,13 +712,13 @@ mod binary_tree_insert {
     fn inserts_three_elements_second_and_third_are_right_children() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 1,
                 left: None,
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 2,
                     left: None,
-                    right: Some(Box::new(Item {
+                    right: Some(Box::new(Node {
                         value: 3,
                         left: None,
                         right: None,
@@ -738,13 +738,13 @@ mod binary_tree_insert {
     fn discards_duplicates_of_right_children() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 1,
                 left: None,
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 2,
                     left: None,
-                    right: Some(Box::new(Item {
+                    right: Some(Box::new(Node {
                         value: 3,
                         left: None,
                         right: None,
@@ -767,11 +767,11 @@ mod binary_tree_insert {
     fn inserts_three_elements_second_and_third_are_left_children() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 3,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 2,
-                    left: Some(Box::new(Item {
+                    left: Some(Box::new(Node {
                         value: 1,
                         left: None,
                         right: None,
@@ -793,11 +793,11 @@ mod binary_tree_insert {
     fn discards_duplicates_of_left_children() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 3,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 2,
-                    left: Some(Box::new(Item {
+                    left: Some(Box::new(Node {
                         value: 1,
                         left: None,
                         right: None,
@@ -822,14 +822,14 @@ mod binary_tree_insert {
     fn inserts_four_elements_zig_zag_starting_left() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 10,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 0,
                     left: None,
-                    right: Some(Box::new(Item {
+                    right: Some(Box::new(Node {
                         value: 5,
-                        left: Some(Box::new(Item {
+                        left: Some(Box::new(Node {
                             value: 3,
                             left: None,
                             right: None,
@@ -853,15 +853,15 @@ mod binary_tree_insert {
     fn inserts_four_elements_zig_zag_starting_right() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 0,
                 left: None,
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 10,
-                    left: Some(Box::new(Item {
+                    left: Some(Box::new(Node {
                         value: 3,
                         left: None,
-                        right: Some(Box::new(Item {
+                        right: Some(Box::new(Node {
                             value: 5,
                             left: None,
                             right: None,
@@ -885,14 +885,14 @@ mod binary_tree_insert {
         let mut tree1 = BinaryTree::new();
         let mut tree2 = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 2,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 1,
                     left: None,
                     right: None,
                 })),
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 3,
                     left: None,
                     right: None,
@@ -920,29 +920,29 @@ mod binary_tree_insert {
     fn creates_three_layer_tree_one_layer_at_a_time() {
         let mut tree = BinaryTree::new();
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 50,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 25,
-                    left: Some(Box::new(Item {
+                    left: Some(Box::new(Node {
                         value: 13,
                         left: None,
                         right: None,
                     })),
-                    right: Some(Box::new(Item {
+                    right: Some(Box::new(Node {
                         value: 37,
                         left: None,
                         right: None,
                     })),
                 })),
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 75,
-                    left: Some(Box::new(Item {
+                    left: Some(Box::new(Node {
                         value: 63,
                         left: None,
                         right: None,
                     })),
-                    right: Some(Box::new(Item {
+                    right: Some(Box::new(Node {
                         value: 87,
                         left: None,
                         right: None,
@@ -1008,20 +1008,20 @@ mod binary_tree_insert {
 
 #[cfg(test)]
 mod binary_tree_std_trait_impls {
-    use super::{BinaryTree, Item};
+    use super::{BinaryTree, Node};
 
     #[test]
     fn creates_tree_from_vec() {
         let values = vec![5, 4, 6];
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 4,
                     left: None,
                     right: None,
                 })),
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 6,
                     left: None,
                     right: None,
@@ -1061,14 +1061,14 @@ mod binary_tree_std_trait_impls {
     fn creates_tree_from_iterator() {
         let tree = BinaryTree::from_iter(vec![5, 4, 6]);
         let expected_tree = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 4,
                     left: None,
                     right: None,
                 })),
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 6,
                     left: None,
                     right: None,
@@ -1086,7 +1086,7 @@ mod binary_tree_std_trait_impls {
 
 #[cfg(all(test, feature = "serde"))]
 mod binary_tree_serde {
-    use super::{BinaryTree, Item};
+    use super::{BinaryTree, Node};
     use rstest::{fixture, rstest};
 
     #[fixture]
@@ -1099,14 +1099,14 @@ mod binary_tree_serde {
         let tree: BinaryTree<i32> =
             serde_json::from_str(json_tree).expect("should parse json into tree");
         let expected = BinaryTree {
-            root: Some(Box::new(Item {
+            root: Some(Box::new(Node {
                 value: 5,
-                left: Some(Box::new(Item {
+                left: Some(Box::new(Node {
                     value: 4,
                     left: None,
                     right: None,
                 })),
-                right: Some(Box::new(Item {
+                right: Some(Box::new(Node {
                     value: 6,
                     left: None,
                     right: None,

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -1,4 +1,4 @@
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BinaryTree<T>
 where
     T: PartialOrd,
@@ -208,7 +208,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 struct Item<T> {
     value: T,
     left: Option<Box<Item<T>>>,

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -283,6 +283,18 @@ impl<T> Iterator for BinaryTreeIterator<T> {
     }
 }
 
+impl<T: PartialOrd> FromIterator<T> for BinaryTree<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut tree = BinaryTree::new();
+
+        for v in iter {
+            tree.insert(v);
+        }
+
+        tree
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 struct Item<T> {
@@ -1043,6 +1055,32 @@ mod binary_tree_std_trait_impls {
         assert_eq!(tree_iter.next(), Some(6));
         assert_eq!(tree_iter.next(), Some(4));
         assert_eq!(tree_iter.next(), None);
+    }
+
+    #[test]
+    fn creates_tree_from_iterator() {
+        let tree = BinaryTree::from_iter(vec![5, 4, 6]);
+        let expected_tree = BinaryTree {
+            root: Some(Box::new(Item {
+                value: 5,
+                left: Some(Box::new(Item {
+                    value: 4,
+                    left: None,
+                    right: None,
+                })),
+                right: Some(Box::new(Item {
+                    value: 6,
+                    left: None,
+                    right: None,
+                })),
+            })),
+            count: 3,
+            height: 2,
+        };
+
+        assert_eq!(tree, expected_tree);
+        assert_eq!(tree.height(), 2);
+        assert_eq!(tree.count(), 3);
     }
 }
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -37,7 +37,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     /// Inserts the provided value into the `BinaryTree`,
     /// and preserves the properties of the binary tree.
     ///
-    /// # Panic
+    /// # Panics
     /// The function will panic if a comparison of elements is impossible with the [`PartialOrd`] trait.
     ///
     /// # Examples

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -32,7 +32,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     /// and preserves the properties of the binary tree.
     ///
     /// # Panic
-    /// The function will panic if a comparison is impossible with the [`PartialOrd`] trait.
+    /// The function will panic if a comparison of elements is impossible with the [`PartialOrd`] trait.
     ///
     /// # Examples
     /// ```

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -282,6 +282,15 @@ impl<T: PartialOrd> FromIterator<T> for BinaryTree<T> {
     }
 }
 
+impl<T: PartialOrd> Extend<T> for BinaryTree<T> {
+    /// Extends the `BinaryTree` with the contents of the provided iterator.
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for v in iter {
+            self.insert(v);
+        }
+    }
+}
+
 impl<T: PartialOrd> IntoIterator for BinaryTree<T> {
     type Item = T;
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -232,7 +232,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     /// assert_eq!(tree_iter.next(), None);
     /// ```
     #[inline]
-    pub fn iter(&self) -> BinaryTreeIterator<'_, T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.as_ref().into_iter()
     }
 }
@@ -348,7 +348,7 @@ impl<T: PartialOrd> FromIterator<T> for BinaryTree<T> {
 impl<'a, T: PartialOrd> IntoIterator for &'a BinaryTree<T> {
     type Item = &'a T;
 
-    type IntoIter = BinaryTreeIterator<'a, T>;
+    type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         let mut values = Vec::with_capacity(self.count);
@@ -370,7 +370,7 @@ impl<'a, T: PartialOrd> IntoIterator for &'a BinaryTree<T> {
             }
         }
 
-        BinaryTreeIterator {
+        Iter {
             vec: values,
             index: 0,
         }
@@ -380,12 +380,12 @@ impl<'a, T: PartialOrd> IntoIterator for &'a BinaryTree<T> {
 /// An iterator that borrows from the `BinaryTree`.
 ///
 /// This `struct` is created by the `iter` method on [`BinaryTree`].
-pub struct BinaryTreeIterator<'a, T> {
+pub struct Iter<'a, T> {
     vec: Vec<&'a T>,
     index: usize,
 }
 
-impl<'a, T> Iterator for BinaryTreeIterator<'a, T> {
+impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -232,6 +232,7 @@ impl<T: PartialOrd> From<Vec<T>> for BinaryTree<T> {
 }
 
 impl<T: PartialOrd> AsRef<BinaryTree<T>> for BinaryTree<T> {
+    /// Returns an immutable reference to the `BinaryTree`.
     #[inline]
     fn as_ref(&self) -> &BinaryTree<T> {
         self

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -239,13 +239,13 @@ impl<T: PartialOrd> AsMut<BinaryTree<T>> for BinaryTree<T> {
     }
 }
 
-impl<T: PartialOrd> IntoIterator for BinaryTree<T> {
-    type Item = T;
+impl<T1: PartialOrd> IntoIterator for BinaryTree<T1> {
+    type Item = T1;
 
-    type IntoIter = BinaryTreeIterator<T>;
+    type IntoIter = BinaryTreeIterator<T1>;
 
     fn into_iter(self) -> Self::IntoIter {
-        fn into_iter_rec<T>(node: Node<T>, vec: &mut Vec<T>) {
+        fn into_iter_rec<T2>(node: Node<T2>, vec: &mut Vec<T2>) {
             vec.push(node.value);
 
             if let Some(left) = node.left {

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -1042,6 +1042,7 @@ mod binary_tree_std_trait_impls {
         assert_eq!(tree_iter.next(), Some(5));
         assert_eq!(tree_iter.next(), Some(6));
         assert_eq!(tree_iter.next(), Some(4));
+        assert_eq!(tree_iter.next(), None);
     }
 }
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -222,6 +222,12 @@ impl<T: PartialOrd> From<Vec<T>> for BinaryTree<T> {
         tree
     }
 }
+
+impl<T: PartialOrd> AsRef<BinaryTree<T>> for BinaryTree<T> {
+    fn as_ref(&self) -> &BinaryTree<T> {
+        self
+    }
+}
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 struct Item<T> {
     value: T,

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -52,62 +52,59 @@ impl<T: PartialOrd> BinaryTree<T> {
     pub fn insert(&mut self, value: T) {
         use std::cmp::Ordering as Ord;
 
-        match self.root.as_deref_mut() {
-            Some(mut root) => {
-                // An empty tree is height 0, while a tree with only a root is height 1
-                // meaning this arm, which is entered when root is not empty
-                // automatically starts at level 2 in terms of height.
-                let mut level: usize = 2;
-                loop {
-                    match (root.left(), root.right()) {
-                        (None, None) => {
-                            match value.partial_cmp(root.value()).unwrap() {
-                                Ord::Equal => return,
-                                Ord::Less => root.set_left(value),
-                                Ord::Greater => root.set_right(value),
-                            }
+        if let Some(mut root) = self.root.as_deref_mut() {
+            // An empty tree is height 0, while a tree with only a root is height 1
+            // meaning this arm, which is entered when root is not empty
+            // automatically starts at level 2 in terms of height.
+            let mut level: usize = 2;
+            loop {
+                match (root.left(), root.right()) {
+                    (None, None) => {
+                        match value.partial_cmp(root.value()).unwrap() {
+                            Ord::Equal => return,
+                            Ord::Less => root.set_left(value),
+                            Ord::Greater => root.set_right(value),
+                        }
+                        self.height = self.height.max(level);
+                        self.count += 1;
+                        return;
+                    }
+                    (None, Some(_)) => match value.partial_cmp(root.value()).unwrap() {
+                        Ord::Equal => return,
+                        Ord::Less => {
+                            root.set_left(value);
                             self.height = self.height.max(level);
                             self.count += 1;
                             return;
                         }
-                        (None, Some(_)) => match value.partial_cmp(root.value()).unwrap() {
-                            Ord::Equal => return,
-                            Ord::Less => {
-                                root.set_left(value);
-                                self.height = self.height.max(level);
-                                self.count += 1;
-                                return;
-                            }
-                            Ord::Greater => root = root.right_mut().unwrap(),
-                        },
-                        (Some(_), None) => match value.partial_cmp(root.value()).unwrap() {
-                            Ord::Equal => return,
-                            Ord::Less => root = root.left_mut().unwrap(),
-                            Ord::Greater => {
-                                root.set_right(value);
-                                self.height = self.height.max(level);
-                                self.count += 1;
-                                return;
-                            }
-                        },
-                        (Some(_), Some(_)) => match value.partial_cmp(root.value()).unwrap() {
-                            Ord::Equal => return,
-                            Ord::Less => root = root.left_mut().unwrap(),
-                            Ord::Greater => root = root.right_mut().unwrap(),
-                        },
-                    }
-
-                    level += 1;
+                        Ord::Greater => root = root.right_mut().unwrap(),
+                    },
+                    (Some(_), None) => match value.partial_cmp(root.value()).unwrap() {
+                        Ord::Equal => return,
+                        Ord::Less => root = root.left_mut().unwrap(),
+                        Ord::Greater => {
+                            root.set_right(value);
+                            self.height = self.height.max(level);
+                            self.count += 1;
+                            return;
+                        }
+                    },
+                    (Some(_), Some(_)) => match value.partial_cmp(root.value()).unwrap() {
+                        Ord::Equal => return,
+                        Ord::Less => root = root.left_mut().unwrap(),
+                        Ord::Greater => root = root.right_mut().unwrap(),
+                    },
                 }
-            }
-            None => {
-                // This ensures that root is not an imcomparable value.
-                _ = value.partial_cmp(&value).unwrap();
 
-                self.root = Some(Box::new(Node::new(value)));
-                self.count = 1;
-                self.height = 1;
+                level += 1;
             }
+        } else {
+            // This ensures that root is not an imcomparable value.
+            _ = value.partial_cmp(&value).unwrap();
+
+            self.root = Some(Box::new(Node::new(value)));
+            self.count = 1;
+            self.height = 1;
         }
     }
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -314,6 +314,7 @@ impl<T> Iterator for BinaryTreeIntoIterator<T> {
 }
 
 impl<T: PartialOrd> FromIterator<T> for BinaryTree<T> {
+    /// Constructs a `BinaryTree<T>` from an iterator for `T`.
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let mut tree = BinaryTree::new();
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -120,6 +120,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     /// tree.insert(0);
     /// assert!(!tree.is_empty());
     /// ```
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.root.is_none()
     }
@@ -138,6 +139,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     /// tree.clear();
     /// assert!(tree.is_empty());
     /// ```
+    #[inline]
     pub fn clear(&mut self) {
         self.root = None;
         self.count = 0;
@@ -167,6 +169,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     /// tree.insert(1);
     /// assert_eq!(tree.height(), 2);
     /// ```
+    #[inline]
     pub fn height(&self) -> usize {
         self.height
     }
@@ -207,6 +210,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     /// tree.insert(6);
     /// assert_eq!(tree.count(), 2);
     /// ```
+    #[inline]
     pub fn count(&self) -> usize {
         self.count
     }
@@ -228,12 +232,14 @@ impl<T: PartialOrd> From<Vec<T>> for BinaryTree<T> {
 }
 
 impl<T: PartialOrd> AsRef<BinaryTree<T>> for BinaryTree<T> {
+    #[inline]
     fn as_ref(&self) -> &BinaryTree<T> {
         self
     }
 }
 
 impl<T: PartialOrd> AsMut<BinaryTree<T>> for BinaryTree<T> {
+    #[inline]
     fn as_mut(&mut self) -> &mut BinaryTree<T> {
         self
     }
@@ -279,6 +285,7 @@ pub struct BinaryTreeIterator<T> {
 impl<T> Iterator for BinaryTreeIterator<T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match self.vec.get(self.index) {
             Some(_) => Some(self.vec.swap_remove(self.index)),
@@ -320,36 +327,43 @@ impl<T: PartialOrd> Node<T> {
     }
 
     /// Returns a reference to the value of the node.
+    #[inline]
     pub fn value(&self) -> &T {
         &self.value
     }
 
     /// Returns an `Option` containing a reference to the left child of the node.
+    #[inline]
     pub fn left(&self) -> Option<&Self> {
         self.left.as_deref()
     }
 
     /// Returns an `Option` containing a reference to the right child of the node.
+    #[inline]
     pub fn right(&self) -> Option<&Self> {
         self.right.as_deref()
     }
 
     /// Returns an `Option` containing a mutable reference to the left child of the node.
+    #[inline]
     pub fn left_mut(&mut self) -> Option<&mut Self> {
         self.left.as_deref_mut()
     }
 
     /// Returns an `Option` containing a mutable reference to the right child of the node.
+    #[inline]
     pub fn right_mut(&mut self) -> Option<&mut Self> {
         self.right.as_deref_mut()
     }
 
     /// Creates a new `Node` from the provided value, and set it as the left child of `self`.
+    #[inline]
     pub fn set_left(&mut self, value: T) {
         self.left = Some(Box::new(Node::new(value)))
     }
 
     /// Creates a new `Node` from the provided value, and set it as the right child of `self`.
+    #[inline]
     pub fn set_right(&mut self, value: T) {
         self.right = Some(Box::new(Node::new(value)))
     }

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -208,6 +208,20 @@ impl<T: PartialOrd> BinaryTree<T> {
     }
 }
 
+impl<T: PartialOrd> From<Vec<T>> for BinaryTree<T> {
+    /// Creates a `BinaryTree<T>` from `Vec<T>`.
+    ///
+    /// # Panic
+    /// The function will panic if a comparison of elements is impossible with the [`PartialOrd`] trait.
+    fn from(vec: Vec<T>) -> Self {
+        let mut tree = BinaryTree::new();
+        for v in vec {
+            tree.insert(v);
+        }
+
+        tree
+    }
+}
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 struct Item<T> {
     value: T,

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -291,6 +291,7 @@ impl<T: PartialOrd> IntoIterator for BinaryTree<T> {
     /// // the iterator is now empty
     /// assert_eq!(tree_iter.next(), None);
     /// ```
+    #[must_use = "iterators are evaluated lazily"]
     fn into_iter(self) -> Self::IntoIter {
         let mut values = Vec::with_capacity(self.count);
         let mut queue = VecDeque::new();

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -232,6 +232,7 @@ impl<T: PartialOrd> BinaryTree<T> {
     /// assert_eq!(tree_iter.next(), None);
     /// ```
     #[inline]
+    #[must_use = "iterators are evaluated lazily"]
     pub fn iter(&self) -> Iter<'_, T> {
         self.as_ref().into_iter()
     }

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -269,6 +269,19 @@ impl<T: PartialOrd> AsMut<BinaryTree<T>> for BinaryTree<T> {
     }
 }
 
+impl<T: PartialOrd> FromIterator<T> for BinaryTree<T> {
+    /// Constructs a `BinaryTree<T>` from an iterator for `T`.
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut tree = BinaryTree::new();
+
+        for v in iter {
+            tree.insert(v);
+        }
+
+        tree
+    }
+}
+
 impl<T: PartialOrd> IntoIterator for BinaryTree<T> {
     type Item = T;
 
@@ -331,19 +344,6 @@ impl<T> Iterator for IntoIter<T> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.vec.next()
-    }
-}
-
-impl<T: PartialOrd> FromIterator<T> for BinaryTree<T> {
-    /// Constructs a `BinaryTree<T>` from an iterator for `T`.
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut tree = BinaryTree::new();
-
-        for v in iter {
-            tree.insert(v);
-        }
-
-        tree
     }
 }
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -964,15 +964,17 @@ mod binary_tree_std_trait_impls {
 #[cfg(all(test, feature = "serde"))]
 mod binary_tree_serde {
     use super::{BinaryTree, Item};
+    use rstest::{fixture, rstest};
 
+    #[fixture]
     fn json_tree() -> &'static str {
-        "{\n  \"root\": {\n    \"value\": 5,\n    \"left\": {\n      \"value\": 4,\n      \"left\": null,\n      \"right\": null\n    },\n    \"right\": {\n      \"value\": 6,\n      \"left\": null,\n      \"right\": null\n    }\n  },\n  \"count\": 3,\n  \"height\": 2\n}"
+        r#"{"root":{"value":5,"left":{"value":4,"left":null,"right":null},"right":{"value":6,"left":null,"right":null}},"count":3,"height":2}"#
     }
 
-    #[test]
-    fn deserializes_tree_from_json() {
+    #[rstest]
+    fn deserializes_tree_from_json(json_tree: &'static str) {
         let tree: BinaryTree<i32> =
-            serde_json::from_str(json_tree()).expect("should parse json into tree");
+            serde_json::from_str(json_tree).expect("should parse json into tree");
         let expected = BinaryTree {
             root: Some(Box::new(Item {
                 value: 5,
@@ -994,15 +996,14 @@ mod binary_tree_serde {
         assert_eq!(tree, expected);
     }
 
-    #[test]
-    fn serialize_tree_into_json() {
+    #[rstest]
+    fn serialize_tree_into_json(json_tree: &'static str) {
         let mut tree = BinaryTree::new();
         tree.insert(5);
         tree.insert(4);
         tree.insert(6);
-        let expected = json_tree();
-        let actual = serde_json::to_string_pretty(&tree).expect("should parse tree into json");
+        let actual = serde_json::to_string(&tree).expect("should parse tree into json");
 
-        assert_eq!(actual, expected);
+        assert_eq!(actual, json_tree);
     }
 }

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -659,7 +659,7 @@ mod node {
 }
 
 #[cfg(test)]
-mod binary_tree_getters {
+mod getters {
     use super::{BinaryTree, Node};
 
     #[test]
@@ -752,7 +752,7 @@ mod binary_tree_getters {
 }
 
 #[cfg(test)]
-mod binary_tree_insert {
+mod insert {
     use super::{BinaryTree, Node};
 
     #[test]
@@ -1129,7 +1129,7 @@ mod binary_tree_insert {
 }
 
 #[cfg(test)]
-mod binary_tree_std_trait_impls {
+mod iterator_trait_impls {
     use super::{BinaryTree, Node};
 
     #[test]
@@ -1342,7 +1342,7 @@ mod binary_tree_std_trait_impls {
 }
 
 #[cfg(all(test, feature = "serde"))]
-mod binary_tree_serde {
+mod json {
     use super::{BinaryTree, Node};
     use rstest::{fixture, rstest};
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -960,3 +960,49 @@ mod binary_tree_std_trait_impls {
         _ = BinaryTree::from(values);
     }
 }
+
+#[cfg(all(test, feature = "serde"))]
+mod binary_tree_serde {
+    use super::{BinaryTree, Item};
+
+    fn json_tree() -> &'static str {
+        "{\n  \"root\": {\n    \"value\": 5,\n    \"left\": {\n      \"value\": 4,\n      \"left\": null,\n      \"right\": null\n    },\n    \"right\": {\n      \"value\": 6,\n      \"left\": null,\n      \"right\": null\n    }\n  },\n  \"count\": 3,\n  \"height\": 2\n}"
+    }
+
+    #[test]
+    fn deserializes_tree_from_json() {
+        let tree: BinaryTree<i32> =
+            serde_json::from_str(json_tree()).expect("should parse json into tree");
+        let expected = BinaryTree {
+            root: Some(Box::new(Item {
+                value: 5,
+                left: Some(Box::new(Item {
+                    value: 4,
+                    left: None,
+                    right: None,
+                })),
+                right: Some(Box::new(Item {
+                    value: 6,
+                    left: None,
+                    right: None,
+                })),
+            })),
+            count: 3,
+            height: 2,
+        };
+
+        assert_eq!(tree, expected);
+    }
+
+    #[test]
+    fn serialize_tree_into_json() {
+        let mut tree = BinaryTree::new();
+        tree.insert(5);
+        tree.insert(4);
+        tree.insert(6);
+        let expected = json_tree();
+        let actual = serde_json::to_string_pretty(&tree).expect("should parse tree into json");
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -240,6 +240,7 @@ impl<T: PartialOrd> AsRef<BinaryTree<T>> for BinaryTree<T> {
 }
 
 impl<T: PartialOrd> AsMut<BinaryTree<T>> for BinaryTree<T> {
+    /// Returns a mutable reference to the `BinaryTree`.
     #[inline]
     fn as_mut(&mut self) -> &mut BinaryTree<T> {
         self

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BinaryTree<T>
 where
@@ -234,6 +238,8 @@ impl<T: PartialOrd> AsMut<BinaryTree<T>> for BinaryTree<T> {
         self
     }
 }
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 struct Item<T> {
     value: T,

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -1060,7 +1060,7 @@ mod binary_tree_std_trait_impls {
     #[test]
     fn creates_tree_from_iterator() {
         let tree = BinaryTree::from_iter(vec![5, 4, 6]);
-        let expected_tree = BinaryTree {
+        let expected = BinaryTree {
             root: Some(Box::new(Node {
                 value: 5,
                 left: Some(Box::new(Node {
@@ -1078,9 +1078,7 @@ mod binary_tree_std_trait_impls {
             height: 2,
         };
 
-        assert_eq!(tree, expected_tree);
-        assert_eq!(tree.height(), 2);
-        assert_eq!(tree.count(), 3);
+        assert_eq!(tree, expected)
     }
 }
 

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -272,7 +272,7 @@ impl<T: PartialOrd> AsMut<BinaryTree<T>> for BinaryTree<T> {
 impl<T: PartialOrd> IntoIterator for BinaryTree<T> {
     type Item = T;
 
-    type IntoIter = BinaryTreeIntoIterator<T>;
+    type IntoIter = IntoIter<T>;
 
     /// Returns a consuming iterator over the `BinaryTree`.
     ///
@@ -311,7 +311,7 @@ impl<T: PartialOrd> IntoIterator for BinaryTree<T> {
             }
         }
 
-        BinaryTreeIntoIterator {
+        IntoIter {
             vec: values.into_iter(),
         }
     }
@@ -320,11 +320,11 @@ impl<T: PartialOrd> IntoIterator for BinaryTree<T> {
 /// An iterator that moves out of the `BinaryTree`.
 ///
 /// This `struct` is created by the `into_iter` method on [`BinaryTree`] (provided by the [`IntoIterator`] trait).
-pub struct BinaryTreeIntoIterator<T> {
+pub struct IntoIter<T> {
     vec: std::vec::IntoIter<T>,
 }
 
-impl<T> Iterator for BinaryTreeIntoIterator<T> {
+impl<T> Iterator for IntoIter<T> {
     type Item = T;
 
     #[inline]

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -228,6 +228,12 @@ impl<T: PartialOrd> AsRef<BinaryTree<T>> for BinaryTree<T> {
         self
     }
 }
+
+impl<T: PartialOrd> AsMut<BinaryTree<T>> for BinaryTree<T> {
+    fn as_mut(&mut self) -> &mut BinaryTree<T> {
+        self
+    }
+}
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 struct Item<T> {
     value: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 #![forbid(unsafe_code)]
+//! # Features
+//! **serde**: derives the serde Serialize and Deserialize on the provided data structures.
 
 pub mod binary_tree;


### PR DESCRIPTION
**This pull request implements the following `std` traits for `BinaryTree`:**
- `Eq`
- `Hash`

**It implement the following conversion traits:**
- `From<Vec>`
- `AsRef`
- `AsMut`

**The following iterator traits:**
- `FromIterator`
- `Extend`
- `IntoIterator` for `BinaryTree`, via the `IntoIter` struct that implements `Iterator`, publicly exposed through the `.into_iter()` method
- `IntoIterator` for `&BinaryTree` via the `Iter` struct that implements `Iterator`, publicly exposed through the `.iter()` method

`IntoIterator` has **not** been implemented for `&mut BinaryTree` as mutating the values of the tree would remove its binary tree properties, making the data structure useless.

**The following third party traits:**
- `Serialize` and `Deserialize` from serde have both been implemented conditionally, and are only available via the `"serde"` feature in the crate.